### PR TITLE
Syncs queue before checking if track already queued

### DIFF
--- a/handlers/djHandlers.test.ts
+++ b/handlers/djHandlers.test.ts
@@ -6,12 +6,7 @@ import {
   queueSong,
   searchSpotifyTrack,
 } from "./djHandlers";
-import {
-  getters,
-  setters,
-  resetDataStores,
-  defaultSettings,
-} from "../lib/dataStore";
+import { setters, resetDataStores } from "../lib/dataStore";
 import sendMessage from "../lib/sendMessage";
 import spotifyApi from "../lib/spotifyApi";
 import refreshSpotifyToken from "../operations/refreshSpotifyToken";
@@ -23,6 +18,7 @@ jest.mock("../lib/spotifyApi", () => ({
   setRefreshToken: jest.fn(),
 }));
 jest.mock("../operations/refreshSpotifyToken");
+jest.mock("../operations/syncQueue");
 
 afterEach(() => {
   jest.restoreAllMocks();
@@ -169,7 +165,7 @@ describe("djHandlers", () => {
   });
 
   describe("queueSong", () => {
-    test("emits SONG_QUEUE_FAILURE event if current user already added it", () => {
+    test("emits SONG_QUEUE_FAILURE event if current user already added it", async () => {
       socket.data.userId = "1";
       setters.setUsers([{ userId: "1", username: "Homer" }]);
       setters.setQueue([
@@ -180,7 +176,7 @@ describe("djHandlers", () => {
         },
       ]);
 
-      queueSong({ socket, io }, "uri");
+      await queueSong({ socket, io }, "uri");
 
       expect(emit).toHaveBeenCalledWith("event", {
         type: "SONG_QUEUE_FAILURE",
@@ -190,7 +186,7 @@ describe("djHandlers", () => {
       });
     });
 
-    test("emits SONG_QUEUE_FAILURE event if other user already queued song", () => {
+    test("emits SONG_QUEUE_FAILURE event if other user already queued song", async () => {
       socket.data.userId = "2";
       setters.setUsers([{ userId: "1", username: "Homer" }]);
       setters.setQueue([
@@ -201,7 +197,7 @@ describe("djHandlers", () => {
         },
       ]);
 
-      queueSong({ socket, io }, "uri");
+      await queueSong({ socket, io }, "uri");
 
       expect(emit).toHaveBeenCalledWith("event", {
         type: "SONG_QUEUE_FAILURE",

--- a/handlers/djHandlers.ts
+++ b/handlers/djHandlers.ts
@@ -6,6 +6,7 @@ import spotifyApi from "../lib/spotifyApi";
 import systemMessage from "../lib/systemMessage";
 import updateUserAttributes from "../lib/updateUserAttributes";
 import refreshSpotifyToken from "../operations/refreshSpotifyToken";
+import syncQueue from "../operations/syncQueue";
 
 import { HandlerConnections } from "../types/HandlerConnections";
 import { SearchOptions } from "../types/SpotifyApi";
@@ -119,6 +120,7 @@ export async function queueSong(
     const currentUser = getters
       .getUsers()
       .find(({ userId }) => userId === socket.data.userId);
+    await syncQueue();
     const inQueue = getters.getQueue().find((x) => x.uri === uri);
 
     if (inQueue) {

--- a/operations/syncQueue.ts
+++ b/operations/syncQueue.ts
@@ -1,0 +1,32 @@
+import spotifyApi from "../lib/spotifyApi";
+import { getters, setters } from "../lib/dataStore";
+import axios from "axios";
+import { SpotifyTrack } from "../types/SpotifyTrack";
+
+const ENDPOINT = "https://api.spotify.com/v1/me/player/queue";
+
+type QueueResponse = {
+  currently_playing?: SpotifyTrack;
+  queue: SpotifyTrack[];
+};
+
+export default async function syncQueue() {
+  try {
+    const accessToken = spotifyApi.getAccessToken();
+    const { data }: { data: QueueResponse } = await axios.get(ENDPOINT, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    const queuedUris = data.queue.map(({ uri }) => uri);
+    const currentQueue = getters.getQueue();
+    setters.setQueue(
+      currentQueue.filter((t) => {
+        return queuedUris.includes(t.uri);
+      })
+    );
+    return getters.getQueue();
+  } catch (e) {
+    return getters.getQueue();
+  }
+}


### PR DESCRIPTION
Removes items from the local queue if they're not present in the Spotify queue before checking if you're queueing an existing track.

closes #6 