### PR TITLE
Fixes "Ballad Time" bug: Load 100 latest messages on join

### DIFF
--- a/src/handlers/authHandlers.ts
+++ b/src/handlers/authHandlers.ts
@@ -195,7 +195,7 @@ export async function login(
   pubUserJoined({ io }, socket.data.roomId, { user: newUser, users: newUsers });
 
   // Get initial data payload for user
-  const messages = await getMessages(roomId, 0, 100);
+  const messages = await getMessages(roomId, -1, -100);
   const playlist = await getRoomPlaylist(roomId);
   const meta = await getRoomCurrent(roomId);
   const allReactions = await getAllRoomReactions(roomId);

--- a/src/operations/data/messages.ts
+++ b/src/operations/data/messages.ts
@@ -24,7 +24,9 @@ export async function getMessages(
     if (!roomExists) {
       return [];
     } else {
-      const results = await pubClient.zRange(roomKey, offset, offset + size);
+      const results = await pubClient.zRange(roomKey, offset, offset + size, {
+        REV: true,
+      });
       return results.map((m) => JSON.parse(m) as ChatMessage) || [];
     }
   } catch (e) {


### PR DESCRIPTION
Changes the `getMessages` implementation to return the latest messages by adding `REV` to the `ZRANGE` call. This fixes a bug where a new user would join and receive only the _first_ 100 messages instead of the 100 most recent. 

This bug is widely known as the "Ballad time" bug. Thanks to @bvarberg for surfacing https://github.com/albatrocity/radio-room-server/pull/20 and greasing the gears.